### PR TITLE
modified docs

### DIFF
--- a/ar/README.md
+++ b/ar/README.md
@@ -9,7 +9,7 @@
 # ابدأ
 ```html
 <meta charset="UTF-8">
-<link rel="import" href="https://jste-manager.azurewebsites.net/loader.min.js">
+<script src="https://jste-manager.herokuapp.com/loader.min.js"></script>
 // كل اﻷكواد التى ستكتبها سوف تكون هنا
 ```
 1\. حتى تبدأ, يجب أن تتأكد أولا من توفر المتطلبات التالية لديك:

--- a/arz/README.md
+++ b/arz/README.md
@@ -9,7 +9,7 @@
 # ابدأ
 ```html
 <meta charset="UTF-8">
-<link rel="import" href="https://jste-manager.azurewebsites.net/loader.min.js">
+<script src="https://jste-manager.herokuapp.com/loader.min.js"></script>
 // كل اﻷكواد اللى انت هتكتبها هتكون هنا
 ```
 1\. عشان تبدأ, لازم الأول تكون متأكد انه عندك المتطلبات دى:

--- a/en-uk/README.md
+++ b/en-uk/README.md
@@ -9,7 +9,7 @@ If you faced any problem while using this documentation, feel free to send us on
 # Get Started
 ```html
 <meta charset="UTF-8">
-<link rel="import" href="https://jste-manager.azurewebsites.net/loader.min.js">
+<script src="https://jste-manager.herokuapp.com/loader.min.js"></script>
 // All of your code will be only here
 ```
 1\. To get started, you have to be sure first that you have the following requirements:

--- a/en-us/README.md
+++ b/en-us/README.md
@@ -9,7 +9,7 @@ If you faced any problem while using this documentation, feel free to send us on
 # Get Started
 ```html
 <meta charset="UTF-8">
-<link rel="import" href="https://jste-manager.azurewebsites.net/loader.min.js">
+<script src="https://jste-manager.herokuapp.com/loader.min.js"></script>
 // All of your code will be only here
 ```
 1\. To get started, you have to be sure first that you have the following requirements:


### PR DESCRIPTION
changed the < link > tag in the "Get Started" Header to <script> tag as it didn't seem to work on most browsers. 